### PR TITLE
Refactor for new types

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ class Event(BaseModel):
 
 ```
 
+#### NewType
+
+
+The NewTypeFactory will generate an uuid7 for a new defined type.
+
+```python
+from typing import NewType
+
+from uuid import UUID
+from pydantic import BaseModel, Field
+
+from lastuuid.utils import NewTypeFactory
+
+
+MessageID = NewType("MessageID", UUID)
+message_id = NewTypeFactory[MessageID](MessageID)
+
+
+class Message(BaseModel):
+    id: UUID = Field(default_factory=message_id)
+
+```
+
+The message_id here will generate a uuid7 typed MessageID,
+
+this avoid to write `MessageID(uuid7())` to have a MessageID typed uuid.
+
+
 #### Performance
 
 On my machine the uuid7 is as fast (or slow) as the native uuid4.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,8 +51,9 @@ autodoc2_packages = [
 
 autodoc2_module_all_regexes = [
     "lastuuid",
-    r"lastuuid\.utils",
+    r"lastuuid\.factories",
     r"lastuuid\.dummies",
+    r"lastuuid\.utils",
 ]
 
 autodoc2_docstring_parser_regexes = [

--- a/docs/source/develop/lastuuid/lastuuid.dummies.md
+++ b/docs/source/develop/lastuuid/lastuuid.dummies.md
@@ -10,12 +10,17 @@
 
 ## Module Contents
 
-### Functions
+### Data
 
 ````{list-table}
 :class: autosummary longtable
 :align: left
 
+* - {py:obj}`uuid7gen <lastuuid.dummies.uuid7gen>`
+  - ```{autodoc2-docstring} lastuuid.dummies.uuid7gen
+    :parser: myst
+    :summary:
+    ```
 * - {py:obj}`uuidgen <lastuuid.dummies.uuidgen>`
   - ```{autodoc2-docstring} lastuuid.dummies.uuidgen
     :parser: myst
@@ -25,10 +30,24 @@
 
 ### API
 
-````{py:function} uuidgen(i: int = 0, j: int = 0, k: int = 0, x: int = 0, y: int = 0) -> uuid.UUID
+````{py:data} uuid7gen
+:canonical: lastuuid.dummies.uuid7gen
+:value: >
+   'LastUUIDFactory(...)'
+
+```{autodoc2-docstring} lastuuid.dummies.uuid7gen
+:parser: myst
+```
+
+````
+
+````{py:data} uuidgen
 :canonical: lastuuid.dummies.uuidgen
+:value: >
+   'LastUUIDFactory(...)'
 
 ```{autodoc2-docstring} lastuuid.dummies.uuidgen
 :parser: myst
 ```
+
 ````

--- a/docs/source/develop/lastuuid/lastuuid.factories.md
+++ b/docs/source/develop/lastuuid/lastuuid.factories.md
@@ -1,0 +1,105 @@
+# {py:mod}`lastuuid.factories`
+
+```{py:module} lastuuid.factories
+```
+
+```{autodoc2-docstring} lastuuid.factories
+:parser: myst
+:allowtitles:
+```
+
+## Module Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`LastUUIDFactory <lastuuid.factories.LastUUIDFactory>`
+  - ```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory
+    :parser: myst
+    :summary:
+    ```
+* - {py:obj}`NewTypeFactory <lastuuid.factories.NewTypeFactory>`
+  - ```{autodoc2-docstring} lastuuid.factories.NewTypeFactory
+    :parser: myst
+    :summary:
+    ```
+````
+
+### API
+
+`````{py:class} LastUUIDFactory(newtype: typing.Any, id_factory: collections.abc.Callable[[], uuid.UUID] = uuid7, cache_size: int = 10)
+:canonical: lastuuid.factories.LastUUIDFactory
+
+Bases: {py:obj}`lastuuid.factories.NewTypeFactory`\[{py:obj}`lastuuid.factories.T`\]
+
+```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory
+:parser: myst
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory.__init__
+:parser: myst
+```
+
+````{py:method} __call__(*args: typing.Any, **kwargs: typing.Any) -> lastuuid.factories.T
+:canonical: lastuuid.factories.LastUUIDFactory.__call__
+
+```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory.__call__
+:parser: myst
+```
+
+````
+
+````{py:property} last
+:canonical: lastuuid.factories.LastUUIDFactory.last
+:type: lastuuid.factories.T
+
+```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory.last
+:parser: myst
+```
+
+````
+
+````{py:property} lasts
+:canonical: lastuuid.factories.LastUUIDFactory.lasts
+:type: list[lastuuid.factories.T]
+
+```{autodoc2-docstring} lastuuid.factories.LastUUIDFactory.lasts
+:parser: myst
+```
+
+````
+
+`````
+
+`````{py:class} NewTypeFactory(newtype: typing.Any, id_factory: collections.abc.Callable[[], uuid.UUID] = uuid7)
+:canonical: lastuuid.factories.NewTypeFactory
+
+Bases: {py:obj}`typing.Generic`\[{py:obj}`lastuuid.factories.T`\]
+
+```{autodoc2-docstring} lastuuid.factories.NewTypeFactory
+:parser: myst
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} lastuuid.factories.NewTypeFactory.__init__
+:parser: myst
+```
+
+````{py:method} __call__(*args: typing.Any, **kwargs: typing.Any) -> lastuuid.factories.T
+:canonical: lastuuid.factories.NewTypeFactory.__call__
+
+```{autodoc2-docstring} lastuuid.factories.NewTypeFactory.__call__
+:parser: myst
+```
+
+````
+
+`````

--- a/docs/source/develop/lastuuid/lastuuid.utils.md
+++ b/docs/source/develop/lastuuid/lastuuid.utils.md
@@ -30,7 +30,7 @@
 
 ### API
 
-````{py:function} uuid7_bounds_from_date(dt: datetime.date, tz=UTC) -> typing_extensions.Tuple[uuid.UUID, uuid.UUID]
+````{py:function} uuid7_bounds_from_date(dt: datetime.date, tz=UTC) -> tuple[uuid.UUID, uuid.UUID]
 :canonical: lastuuid.utils.uuid7_bounds_from_date
 
 ```{autodoc2-docstring} lastuuid.utils.uuid7_bounds_from_date
@@ -38,7 +38,7 @@
 ```
 ````
 
-````{py:function} uuid7_bounds_from_datetime(dt_lower: datetime.datetime, dt_upper: datetime.datetime | None = None) -> typing_extensions.Tuple[uuid.UUID, uuid.UUID]
+````{py:function} uuid7_bounds_from_datetime(dt_lower: datetime.datetime, dt_upper: datetime.datetime | None = None) -> tuple[uuid.UUID, uuid.UUID]
 :canonical: lastuuid.utils.uuid7_bounds_from_datetime
 
 ```{autodoc2-docstring} lastuuid.utils.uuid7_bounds_from_datetime

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,6 +8,7 @@
 
 develop/lastuuid/lastuuid
 develop/lastuuid/lastuuid.dummies
+develop/lastuuid/lastuuid.factories
 develop/lastuuid/lastuuid.utils
 ```
 

--- a/lastuuid/dummies.py
+++ b/lastuuid/dummies.py
@@ -5,14 +5,12 @@ UUID generated here are full of 0, they does not respect any kind of UUID versio
 they remove a bit of cognitive load while testing.
 """
 
-from collections import deque
-from typing import Any, Deque, Iterator
+from typing import Iterator
 from uuid import UUID
 
-from lastuuid import uuid7
-from lastuuid.utils import LastUUIDFactory, T
+from lastuuid.factories import LastUUIDFactory
 
-__all__ = ["uuidgen", "uuid7gen", "LastUUID7Factory"]
+__all__ = ["uuidgen", "uuid7gen"]
 
 
 def gen_id() -> Iterator[int]:
@@ -26,51 +24,82 @@ next_id = gen_id()
 
 
 def _uuidgen(i: int = 0, j: int = 0, k: int = 0, x: int = 0, y: int = 0) -> UUID:
-    """
-    A UUID generator that makes UUIDs more readable for humans.
-
-    # Generate autoincrement UUID that you need to predict
-
-    Sometime you prepare fixtures with well known UUID and you want to repeat them,
-
-    uuidgen(1) is more readable that UUID('00000001-0000-0000-0000-000000000000'),
-    this is why this function is made for.
-    Every section of the uuid can be filled out using `i`, `j`, `k`, `x`, `y` but,
-    I personnaly never use more than `i` and `j`.
-
-    ```python
-    >>> from lastuuid.dummies import uuidgen
-    >>> uuidgen(1)
-    UUID('00000001-0000-0000-0000-000000000000')
-    >>> uuidgen(1, 2)
-    UUID('00000001-0002-0000-0000-000000000000')
-    >>> uuidgen(1, 2, 3, 4, 5)
-    UUID('00000001-0002-0003-0004-000000000005')
-    ```
-
-    ```{tip}
-    if you don't want a dependency for that, the standard library let you write
-    UUID(int=1) which produce UUID('00000000-0000-0000-0000-000000000001').
-    ```
-
-    # Generate autoincrement UUID that you don't need to predict
-
-    Without any parameter, it will generate UUID where the last bits are incremented.
-
-    ```python
-    >>> from lastuuid.dummies import uuidgen
-    >>> uuidgen()
-    UUID('00000000-0000-0000-0000-000000000001')
-    >>> uuidgen()
-    UUID('00000000-0000-0000-0000-000000000002')
-    ```
-
-    """
     if i == 0 and y == 0:
         y = next(next_id)
     return UUID(f"{i:0>8}-{j:0>4}-{k:0>4}-{x:0>4}-{y:0>12}")
 
 
 uuidgen = LastUUIDFactory(None, _uuidgen)
+"""
+A UUID generator that makes UUIDs more readable for humans.
+
+# Generate autoincrement UUID that you need to predict
+
+Sometime you prepare fixtures with well known UUID and you want to repeat them,
+
+uuidgen(1) is more readable that UUID('00000001-0000-0000-0000-000000000000'),
+this is why this function is made for.
+Every section of the uuid can be filled out using `i`, `j`, `k`, `x`, `y` but,
+I personnaly never use more than `i` and `j`.
+
+```python
+>>> from lastuuid.dummies import uuidgen
+>>> uuidgen(1)
+UUID('00000001-0000-0000-0000-000000000000')
+>>> uuidgen(1, 2)
+UUID('00000001-0002-0000-0000-000000000000')
+>>> uuidgen(1, 2, 3, 4, 5)
+UUID('00000001-0002-0003-0004-000000000005')
+```
+
+```{tip}
+if you don't want a dependency for that, the standard library let you write
+UUID(int=1) which produce UUID('00000000-0000-0000-0000-000000000001').
+```
+
+# Generate autoincrement UUID that you don't need to predict
+
+Without any parameter, it will generate UUID where the last bits are incremented.
+It also keep the 10 lasts created values.
+
+```python
+>>> from lastuuid.dummies import uuidgen
+>>> uuidgen()
+UUID('00000000-0000-0000-0000-000000000001')
+>>> uuidgen.last
+UUID('00000000-0000-0000-0000-000000000001')
+>>> uuidgen()
+UUID('00000000-0000-0000-0000-000000000002')
+>>> uuidgen.last
+UUID('00000000-0000-0000-0000-000000000002')
+>>> uuidgen.lasts[1]
+UUID('00000000-0000-0000-0000-000000000001')
+```
+
+"""
 
 uuid7gen = LastUUIDFactory(None)
+"""
+Generate uuid7 and store the last generated values to get them
+using last and lasts property.
+
+```python
+>>> from lastuuid.dummies import uuid7gen
+>>> uuid7gen()
+UUID('019b5cb2-2fea-7572-8fc6-84fc550278e8')
+>>> uuid7gen.last
+UUID('019b5cb2-2fea-7572-8fc6-84fc550278e8')
+>>> uuid7gen.lasts
+[UUID('019b5cb2-2fea-7572-8fc6-84fc550278e8')]
+>>> uuid7gen()
+UUID('019b5cb2-82e5-709d-a24d-7dba31eb3e82')
+>>> uuid7gen.last
+UUID('019b5cb2-82e5-709d-a24d-7dba31eb3e82')
+>>> uuid7gen.last[0]
+UUID('019b5cb2-82e5-709d-a24d-7dba31eb3e82')
+>>> uuid7gen.lasts[1]
+UUID('019b5cb2-2fea-7572-8fc6-84fc550278e8')
+```
+
+See also {class}`lastuuid.factories.LastUUIDFactory`.
+"""

--- a/lastuuid/factories.py
+++ b/lastuuid/factories.py
@@ -1,0 +1,104 @@
+"""
+Factories for new types.
+"""
+
+from collections import deque
+from collections.abc import Callable
+from typing import Any, Deque, Generic, TypeVar
+from uuid import UUID
+
+from .lastuuid import uuid7
+
+__all__ = [
+    "NewTypeFactory",
+    "LastUUIDFactory",
+]
+
+
+T = TypeVar("T", bound=UUID)
+
+
+class NewTypeFactory(Generic[T]):
+    """
+    Factory for NewType UUIDs
+    """
+
+    def __init__(self, newtype: Any, id_factory: Callable[[], UUID] = uuid7):
+        """
+        Create a factory of type that store the last instances.
+
+        :param newtype: the type to be used
+        :param id_factory: the factory to use, uuid7 by default.
+        """
+        self._newtype = newtype
+        self._id_factory = id_factory
+
+    def __call__(self, *args: Any, **kwargs: Any) -> T:
+        """Generate a new value."""
+        val = self._id_factory(*args, **kwargs)  # type: ignore
+        if self._newtype:
+            val: T = self._newtype(val)  # cast to NewType
+        return val
+
+
+class LastUUIDFactory(NewTypeFactory[T]):
+    """
+    Keep last UUID generated.
+
+    ```python
+    >>> from typing import NewType
+    >>> from uuid import UUID
+    >>> from lastuuid.utils import LastUUIDFactory
+    >>> ClientId = NewType("ClientId", UUID)
+    >>> client_id_factory = LastUUIDFactory[ClientId](ClientId)
+    >>> client_id_factory()
+    UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
+    >>> client_id_factory()
+    UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
+    >>> client_id_factory()
+    UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+    >>> client_id_factory.last
+    UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+    >>> client_id_factory.lasts[0]
+    UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+    >>> client_id_factory.lasts[1]
+    UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
+    >>> client_id_factory.lasts[2]
+    UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
+    ```
+    """
+    def __init__(
+        self,
+        newtype: Any,
+        id_factory: Callable[[], UUID] = uuid7,
+        cache_size: int = 10,
+    ):
+        """
+        Create a factory of type that store the last instances.
+
+        :param newtype: the type to be used
+        :param cache_size: size of the queue that saved the last uuids
+        """
+        super().__init__(newtype, id_factory)
+        self._cache: Deque[T] = deque(maxlen=cache_size)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> T:
+        """Generate the id and cache it."""
+        val = super().__call__(*args, **kwargs)
+        self._cache.append(val)
+        return val
+
+    @property
+    def last(self) -> T:
+        """Most recently generated UUID-NewType instance."""
+        return self._cache[-1]
+
+    @property
+    def lasts(self) -> list[T]:
+        """
+        Returns a list of the last N generated UUID-NewType instances.
+
+        The list is ordered from most recent to oldest.
+        The most recent value is accessible via `last`.
+        """
+        return list(reversed(self._cache))

--- a/lastuuid/utils.py
+++ b/lastuuid/utils.py
@@ -21,13 +21,42 @@ This documentation does not cover the book Designing Data-Intensive Applications
 ```
 """
 
+from collections.abc import Callable
 from datetime import UTC, date, datetime, time, timedelta
+from typing import Any, Generic, TypeVar
 from uuid import UUID
+
+from .lastuuid import uuid7
 
 __all__ = [
     "uuid7_bounds_from_datetime",
     "uuid7_bounds_from_date",
 ]
+
+
+T = TypeVar("T", bound=UUID)
+
+
+class NewTypeFactory(Generic[T]):
+    """
+    Factory for NewType UUIDs
+    """
+
+    def __init__(self, newtype: Any, id_factory: Callable[[], UUID] = uuid7):
+        """
+        Create a factory of type that store the last instances.
+
+        :param newtype: the type to be used
+        :param id_factory: the factory to use, uuid7 by default.
+        """
+        self._newtype = newtype
+        self._id_factory = id_factory
+
+    def __call__(self) -> T:
+        val = self._id_factory()  # type: ignore
+        if self._newtype:
+            val: T = self._newtype(val)  # cast to NewType
+        return val
 
 
 def _datetime_to_uuid7_lowest(dt: datetime) -> UUID:

--- a/lastuuid/utils.py
+++ b/lastuuid/utils.py
@@ -21,9 +21,10 @@ This documentation does not cover the book Designing Data-Intensive Applications
 ```
 """
 
+from collections import deque
 from collections.abc import Callable
 from datetime import UTC, date, datetime, time, timedelta
-from typing import Any, Generic, TypeVar
+from typing import Any, Deque, Generic, TypeVar
 from uuid import UUID
 
 from .lastuuid import uuid7
@@ -52,11 +53,70 @@ class NewTypeFactory(Generic[T]):
         self._newtype = newtype
         self._id_factory = id_factory
 
-    def __call__(self) -> T:
-        val = self._id_factory()  # type: ignore
+    def __call__(self, *args: Any, **kwargs: Any) -> T:
+        val = self._id_factory(*args, **kwargs)  # type: ignore
         if self._newtype:
             val: T = self._newtype(val)  # cast to NewType
         return val
+
+
+class LastUUIDFactory(NewTypeFactory[T]):
+    def __init__(
+        self,
+        newtype: Any,
+        id_factory: Callable[[], UUID] = uuid7,
+        cache_size: int = 10,
+    ):
+        """
+        Create a factory of type that store the last instances.
+
+        ```python
+        >>> from typing import NewType
+        >>> from uuid import UUID
+        >>> from lastuuid.utils import LastUUIDFactory
+        >>> ClientId = NewType("ClientId", UUID)
+        >>> client_id_factory = LastUUIDFactory[ClientId](ClientId)
+        >>> client_id_factory()
+        UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
+        >>> client_id_factory()
+        UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
+        >>> client_id_factory()
+        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+        >>> client_id_factory.last
+        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+        >>> client_id_factory.lasts[0]
+        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
+        >>> client_id_factory.lasts[1]
+        UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
+        >>> client_id_factory.lasts[2]
+        UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
+        ```
+
+        :param newtype: the type to be used
+        :param cache_size: size of the queue that saved the last uuids
+        """
+        super().__init__(newtype, id_factory)
+        self._cache: Deque[T] = deque(maxlen=cache_size)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> T:
+        val = super().__call__(*args, **kwargs)
+        self._cache.append(val)
+        return val
+
+    @property
+    def last(self) -> T:
+        """Most recently generated UUID-NewType instance."""
+        return self._cache[-1]
+
+    @property
+    def lasts(self) -> list[T]:
+        """
+        Returns a list of the last N generated UUID-NewType instances.
+
+        The list is ordered from most recent to oldest.
+        The most recent value is accessible via `last`.
+        """
+        return list(reversed(self._cache))
 
 
 def _datetime_to_uuid7_lowest(dt: datetime) -> UUID:

--- a/lastuuid/utils.py
+++ b/lastuuid/utils.py
@@ -9,114 +9,15 @@ The design of UUIDv7 feet well with the design of BTree.
 Because they contains a date time, a UUID range can be compute
 in order to retrieve UUIDs generated at a given time.
 
-
-```{important}
-In a distributed system, relying solely on a datetime or UUIDv7 for sorting
-has limitations.
-While UUIDv7 ensures sequential ordering on a single machine, there is no guarantee
-that a UUIDv7 generated later on one machine will be greater than one generated
-earlier on another machine.
-
-This documentation does not cover the book Designing Data-Intensive Applications ;).
-```
 """
 
-from collections import deque
-from collections.abc import Callable
 from datetime import UTC, date, datetime, time, timedelta
-from typing import Any, Deque, Generic, TypeVar
 from uuid import UUID
-
-from .lastuuid import uuid7
 
 __all__ = [
     "uuid7_bounds_from_datetime",
     "uuid7_bounds_from_date",
 ]
-
-
-T = TypeVar("T", bound=UUID)
-
-
-class NewTypeFactory(Generic[T]):
-    """
-    Factory for NewType UUIDs
-    """
-
-    def __init__(self, newtype: Any, id_factory: Callable[[], UUID] = uuid7):
-        """
-        Create a factory of type that store the last instances.
-
-        :param newtype: the type to be used
-        :param id_factory: the factory to use, uuid7 by default.
-        """
-        self._newtype = newtype
-        self._id_factory = id_factory
-
-    def __call__(self, *args: Any, **kwargs: Any) -> T:
-        val = self._id_factory(*args, **kwargs)  # type: ignore
-        if self._newtype:
-            val: T = self._newtype(val)  # cast to NewType
-        return val
-
-
-class LastUUIDFactory(NewTypeFactory[T]):
-    def __init__(
-        self,
-        newtype: Any,
-        id_factory: Callable[[], UUID] = uuid7,
-        cache_size: int = 10,
-    ):
-        """
-        Create a factory of type that store the last instances.
-
-        ```python
-        >>> from typing import NewType
-        >>> from uuid import UUID
-        >>> from lastuuid.utils import LastUUIDFactory
-        >>> ClientId = NewType("ClientId", UUID)
-        >>> client_id_factory = LastUUIDFactory[ClientId](ClientId)
-        >>> client_id_factory()
-        UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
-        >>> client_id_factory()
-        UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
-        >>> client_id_factory()
-        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
-        >>> client_id_factory.last
-        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
-        >>> client_id_factory.lasts[0]
-        UUID('019b4f7d-f9d2-7471-b6bb-c490f5b50e3a')
-        >>> client_id_factory.lasts[1]
-        UUID('019b4f7d-f9d2-7471-b6bb-c48f31146c56')
-        >>> client_id_factory.lasts[2]
-        UUID('019b4f7d-f9d1-7d46-922a-7b83c4462366')
-        ```
-
-        :param newtype: the type to be used
-        :param cache_size: size of the queue that saved the last uuids
-        """
-        super().__init__(newtype, id_factory)
-        self._cache: Deque[T] = deque(maxlen=cache_size)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> T:
-        val = super().__call__(*args, **kwargs)
-        self._cache.append(val)
-        return val
-
-    @property
-    def last(self) -> T:
-        """Most recently generated UUID-NewType instance."""
-        return self._cache[-1]
-
-    @property
-    def lasts(self) -> list[T]:
-        """
-        Returns a list of the last N generated UUID-NewType instances.
-
-        The list is ordered from most recent to oldest.
-        The most recent value is accessible via `last`.
-        """
-        return list(reversed(self._cache))
 
 
 def _datetime_to_uuid7_lowest(dt: datetime) -> UUID:

--- a/tests/test_dummies.py
+++ b/tests/test_dummies.py
@@ -1,4 +1,3 @@
-from typing import NewType
 from uuid import UUID
 
 from lastuuid.dummies import uuid7gen, uuidgen

--- a/tests/test_dummies.py
+++ b/tests/test_dummies.py
@@ -1,11 +1,12 @@
 from typing import NewType
 from uuid import UUID
 
-from lastuuid.dummies import LastUUID7Factory, uuid7gen, uuidgen
+from lastuuid.dummies import uuid7gen, uuidgen
 
 
 def test_default():
-    assert uuidgen() == UUID(int=1)
+    assert uuidgen() == UUID(int=1)  # XXX this tests works because it is the first
+    assert uuidgen.last == UUID(int=1)
 
 
 def test_predictable():
@@ -16,11 +17,3 @@ def test_predictable():
 def test_predictable_uuid7():
     myid = uuid7gen()
     assert myid == uuid7gen.last
-
-
-def test_predictable_uuid7_new_type():
-    ClientId = NewType("ClientId", UUID)
-
-    client_id_factory = LastUUID7Factory[ClientId](ClientId)
-    myid = client_id_factory()
-    assert myid == client_id_factory.last

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,28 @@
+from typing import NewType, assert_type
+from uuid import UUID
+
+from lastuuid.factories import (
+    LastUUIDFactory,
+    NewTypeFactory,
+)
+
+
+def test_newtype_factory():
+    UserId = NewType("UserId", UUID)
+    newtype = NewTypeFactory[UserId](UserId)
+    val = newtype()
+    assert_type(val, UserId)
+
+
+def test_last_uuid_factory():
+    ClientId = NewType("ClientId", UUID)
+
+    client_id_factory = LastUUIDFactory[ClientId](ClientId, cache_size=2)
+    myid = client_id_factory()
+    assert myid == client_id_factory.last
+    myid2 = client_id_factory()
+    assert myid2 == client_id_factory.last
+    assert [myid2, myid] == client_id_factory.lasts
+    myid3 = client_id_factory()
+    assert myid3 == client_id_factory.last
+    assert [myid3, myid2] == client_id_factory.lasts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,34 +1,10 @@
 from datetime import UTC, date, datetime
-from typing import NewType, assert_type
 from uuid import UUID
 
 from lastuuid.utils import (
-    LastUUIDFactory,
-    NewTypeFactory,
     uuid7_bounds_from_date,
     uuid7_bounds_from_datetime,
 )
-
-
-def test_newtype_factory():
-    UserId = NewType("UserId", UUID)
-    newtype = NewTypeFactory[UserId](UserId)
-    val = newtype()
-    assert_type(val, UserId)
-
-
-def test_last_uuid_factory():
-    ClientId = NewType("ClientId", UUID)
-
-    client_id_factory = LastUUIDFactory[ClientId](ClientId, cache_size=2)
-    myid = client_id_factory()
-    assert myid == client_id_factory.last
-    myid2 = client_id_factory()
-    assert myid2 == client_id_factory.last
-    assert [myid2, myid] == client_id_factory.lasts
-    myid3 = client_id_factory()
-    assert myid3 == client_id_factory.last
-    assert [myid3, myid2] == client_id_factory.lasts
 
 
 def test_uuid7_range_from_datetime():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,19 @@
+from datetime import UTC, date, datetime
+from typing import NewType, assert_type
 from uuid import UUID
-from datetime import date, datetime, UTC
-
 
 from lastuuid.utils import (
+    NewTypeFactory,
     uuid7_bounds_from_date,
     uuid7_bounds_from_datetime,
 )
+
+
+def test_newtype_factory():
+    UserId = NewType("UserId", UUID)
+    newtype = NewTypeFactory[UserId](UserId)
+    val = newtype()
+    assert_type(val, UserId)
 
 
 def test_uuid7_range_from_datetime():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from typing import NewType, assert_type
 from uuid import UUID
 
 from lastuuid.utils import (
+    LastUUIDFactory,
     NewTypeFactory,
     uuid7_bounds_from_date,
     uuid7_bounds_from_datetime,
@@ -14,6 +15,20 @@ def test_newtype_factory():
     newtype = NewTypeFactory[UserId](UserId)
     val = newtype()
     assert_type(val, UserId)
+
+
+def test_last_uuid_factory():
+    ClientId = NewType("ClientId", UUID)
+
+    client_id_factory = LastUUIDFactory[ClientId](ClientId, cache_size=2)
+    myid = client_id_factory()
+    assert myid == client_id_factory.last
+    myid2 = client_id_factory()
+    assert myid2 == client_id_factory.last
+    assert [myid2, myid] == client_id_factory.lasts
+    myid3 = client_id_factory()
+    assert myid3 == client_id_factory.last
+    assert [myid3, myid2] == client_id_factory.lasts
 
 
 def test_uuid7_range_from_datetime():


### PR DESCRIPTION
the new types helper is usefull enough to not be dummy,

so I refactor it to be usable without the cache, and use the cache for all the dummies.