### PR TITLE
Build lastuuid for more python version

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -78,11 +78,11 @@ jobs:
           - os: windows
             target: i686
             python-architecture: x86
-            interpreter: pypy3.11 3.10 3.11 3.12 3.13 3.14 3.14t
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: windows
             target: aarch64
             runs-on: windows-11-arm
-            interpreter: pypy3.11 3.10 3.11 3.12 3.13 3.14 3.14t
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
 
     runs-on: ${{ matrix.runs-on || format('{0}-latest', (matrix.os == 'linux' && 'ubuntu') || matrix.os) }}
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.10 3.11 3.12 3.13 3.14 3.14t' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || 'pypy3.10 pypy3.11 3.10 3.11 3.12 3.13 3.14 3.14t' }}
           rust-toolchain: 'stable'
           docker-options: -e CI
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,15 +45,15 @@ jobs:
           - os: linux
             manylinux: auto
             target: armv7
-            interpreter: 3.11 3.12 3.13
+            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: linux
             manylinux: auto
             target: ppc64le
-            interpreter: 3.11 3.12 3.13
+            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: linux
             manylinux: auto
             target: s390x
-            interpreter: 3.11 3.12 3.13
+            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: linux
             manylinux: auto
             target: x86_64
@@ -69,23 +69,26 @@ jobs:
 
           - os: macos
             target: x86_64
-          # - os: macos
-          #   target: aarch64
-          #   interpreter: pypy3.10
+          - os: macos
+            target: aarch64
+            # interpreter:  pypy3.10 pypy3.11
 
           - os: windows
             target: x86_64
-            interpreter: 3.11 3.12 3.13
+            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: windows
             target: i686
             python-architecture: x86
-            interpreter: 3.11 3.12 3.13
+            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
+          - os: windows
+            target: aarch64
+            runs-on: windows-11-arm
         exclude:
           # Exclude failed build
           - os: windows
             target: aarch64
 
-    runs-on: ${{ (matrix.os == 'linux' && 'ubuntu') || matrix.os }}-latest
+    runs-on: ${{ matrix.runs-on || format('{0}-latest', (matrix.os == 'linux' && 'ubuntu') || matrix.os) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -102,7 +105,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.11 3.12 3.13' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.10 3.11 3.12 3.13 3.14 3.14t' }}
           rust-toolchain: 'stable'
           docker-options: -e CI
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -75,18 +75,14 @@ jobs:
 
           - os: windows
             target: x86_64
-            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: windows
             target: i686
             python-architecture: x86
-            # interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t
+            interpreter: pypy3.11 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: windows
             target: aarch64
             runs-on: windows-11-arm
-        exclude:
-          # Exclude failed build
-          - os: windows
-            target: aarch64
+            interpreter: pypy3.11 3.10 3.11 3.12 3.13 3.14 3.14t
 
     runs-on: ${{ matrix.runs-on || format('{0}-latest', (matrix.os == 'linux' && 'ubuntu') || matrix.os) }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
  "libc",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-pyo3 = { version = "0.27.2", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { version = "0.26.0", features = ["extension-module", "generate-import-lib"] }
 uuid7 = "1.4.0"
 
 [lib]


### PR DESCRIPTION
* Switch back to py03 0.26.0 since 0.27 drop support of python 3.10 which is not EOL yet.
* Update github workflows to build on more python interpreter / OS / processor architecture.