### PR TITLE
Add uv config to rebuild automatically on change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Changelog = "https://mardiros.github.io/lastuuid/changelog.html"
 
 [tool.uv]
 default-groups = []
+cache-keys = [{file = "src/*.rs"}]
 
 # used by sphinx-notes/pages@v3
 [project.optional-dependencies]


### PR DESCRIPTION
Adding the cache-keys settings will automatically rebuild the rust part when .rs files are changed, when using uv commands like uv run